### PR TITLE
Conform to sysrepo/sysrepo-cpp string changes

### DIFF
--- a/src/ietf-hardware-plugin.cc
+++ b/src/ietf-hardware-plugin.cc
@@ -33,7 +33,7 @@ int sr_plugin_init_cb(sr_session_ctx_t* session, void** /*private_data*/) {
     try {
         hardware::HardwareSensors::getInstance().injectConnection(conn);
         sysrepo::Subscription sub = ses.onModuleChange(
-            HardwareModel::moduleName.c_str(), &hardware::Callback::configurationCallback, nullptr,
+            HardwareModel::moduleName.c_str(), &hardware::Callback::configurationCallback, std::nullopt,
             0, sysrepo::SubscribeOptions::Enabled | sysrepo::SubscribeOptions::DoneOnly);
         sub.onOperGet(HardwareModel::moduleName.c_str(), &hardware::Callback::operationalCallback,
                       oper_xpath.c_str());


### PR DESCRIPTION
Callback function now expects `std::string` instead of c-strings (`std::nullopt` instead of `nullptr`). The change was introducted by commit sysrepo/sysrepo-cpp@137cb7295735d416a7dbf3568009f5215e820816 and is the cause of following runtime error:

```console
# sysrepo-plugind -f -d
[ERR] IETF-Hardware: sr_plugin_init_cb: basic_string::_M_construct null not valid
#
```
